### PR TITLE
Introduce lfs to store image files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 src-tauri/icons/* filter=lfs diff=lfs merge=lfs -text
+*.svg filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src-tauri/icons/* filter=lfs diff=lfs merge=lfs -text

--- a/public/leptos.svg
+++ b/public/leptos.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f229c05aefaf7374eec2edda9a15f63efa6e7ed9cb9be81b87697beee5523748
+size 6622

--- a/public/tauri.svg
+++ b/public/tauri.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5d2738bbaa5543c4684001a558dc53165da9b636144827b28db1dcfacf81aa8
+size 2599

--- a/src-tauri/icons/128x128.png
+++ b/src-tauri/icons/128x128.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19b4fec485db7df51a691fcce72a3dd6f983e754fc4262da7154e4a4c688f69e
+size 3512

--- a/src-tauri/icons/128x128@2x.png
+++ b/src-tauri/icons/128x128@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c7660390d65217fe8de0892862254f47aee77e0af7096c75b8bfe168c5403f7
+size 7012

--- a/src-tauri/icons/32x32.png
+++ b/src-tauri/icons/32x32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c6782dc65c8111c12cbc1882a0fea5e71ab8e51b18da2ce9580f5c88860ed02
+size 974

--- a/src-tauri/icons/Square107x107Logo.png
+++ b/src-tauri/icons/Square107x107Logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54f7a0f58c96a4b023c1edc4b53fc443e27dace50e345f6936fa29bc20f785ca
+size 2863

--- a/src-tauri/icons/Square142x142Logo.png
+++ b/src-tauri/icons/Square142x142Logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fec1e2080ca73cd4c4a123b23b1cd364059a8a8efeba3076e21dfefed390693b
+size 3858

--- a/src-tauri/icons/Square150x150Logo.png
+++ b/src-tauri/icons/Square150x150Logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65fb570cb0e61ffce02ad67784cb200a0bf058400300980a46fa0d0c8f43a77a
+size 3966

--- a/src-tauri/icons/Square284x284Logo.png
+++ b/src-tauri/icons/Square284x284Logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea0b7c5d4b1d1ab9c91d2f7c9b069c8dfbf4557b0649a5777d47332cde610262
+size 7737

--- a/src-tauri/icons/Square30x30Logo.png
+++ b/src-tauri/icons/Square30x30Logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc72279c41b4ed343e8db7e7541ceef7b6b23edaa83d4e7338421dfcb8d63c33
+size 903

--- a/src-tauri/icons/Square310x310Logo.png
+++ b/src-tauri/icons/Square310x310Logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9733a89c539115de3c49bd06720bfc99639d9a918f5df48a810e267cf3554119
+size 8591

--- a/src-tauri/icons/Square44x44Logo.png
+++ b/src-tauri/icons/Square44x44Logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10be9840e58fb018eb9029601d42008e16c0c9cfa66b8f9467fee94f600160d4
+size 1299

--- a/src-tauri/icons/Square71x71Logo.png
+++ b/src-tauri/icons/Square71x71Logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2937fc83324cd9a1fddcfefd5927c791af31996a6840bfb3e2f1d578ad4129de
+size 2011

--- a/src-tauri/icons/Square89x89Logo.png
+++ b/src-tauri/icons/Square89x89Logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12aed0e7ee06cb631427dc9da72c0c7ecf03857fbc4884d0c31f78314feb6c7f
+size 2468

--- a/src-tauri/icons/StoreLogo.png
+++ b/src-tauri/icons/StoreLogo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91a54024dd47230991546088f2e75d3e3199b3ccc9fe40f3f6b7d3bf1cbf7776
+size 1523

--- a/src-tauri/icons/icon.icns
+++ b/src-tauri/icons/icon.icns
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3dc10493b7de48a61de58f768f8a5708d3a44a068c148cedf0502b9b9b71ba5d
+size 98451

--- a/src-tauri/icons/icon.ico
+++ b/src-tauri/icons/icon.ico
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:392206b573a809997f3ff16fe68f456a52e931c372107eade9572b329bbe3321
+size 86642

--- a/src-tauri/icons/icon.png
+++ b/src-tauri/icons/icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:273cd669e07c455ad1c7c095890a37984652157cee73128a867300067dfb80e7
+size 14183


### PR DESCRIPTION
Store all files in icons, and "*.svgs" as lfs file pointers. 
Not really necessary for the small image sizes, but establishing best practice for later uploads (may include 4K images)